### PR TITLE
Simplified css

### DIFF
--- a/lib/ClusterThumbView/ClusterThumbView.js
+++ b/lib/ClusterThumbView/ClusterThumbView.js
@@ -35,10 +35,8 @@ var ClusterThumbView = function (_React$Component) {
     value: function () {
       function style() {
         var style = {
-          width: "10em",
+          minWidth: "10em",
           minHeight: "10em",
-          float: "left",
-          margin: ".5em",
           backgroundColor: "#FFFFFF"
         };
         return Object.assign({}, style, this.props.style);

--- a/lib/ClusterToggleView/ClusterToggleView.js
+++ b/lib/ClusterToggleView/ClusterToggleView.js
@@ -49,7 +49,7 @@ var ClusterToggleView = function (_React$Component) {
     _this.getDetailElement = _this.getDetailElement.bind(_this);
 
     if (_react2['default'].Children.count(_this.props.children) > 2) {
-      throw new Error("Too many Children Elements");
+      throw new Error("Too many Child Elements");
     }
     return _this;
   }
@@ -60,8 +60,8 @@ var ClusterToggleView = function (_React$Component) {
       function getThumbElement() {
         if (this.props.thumbElement) {
           return this.props.thumbElement;
-        } else if (_react2['default'].Children.count(this.props.children) === 2) {
-          return this.props.children[0];
+        } else if (_react2['default'].Children.count(this.props.children) >= 1) {
+          return Array.isArray(this.props.children) ? this.props.children[0] : this.props.children;
         } else {
           throw new Error("No Thumb Element to Render");
         }
@@ -95,14 +95,14 @@ var ClusterToggleView = function (_React$Component) {
       return onToggleView;
     }()
   }, {
-    key: 'getView',
+    key: 'render',
     value: function () {
-      function getView() {
+      function render() {
         var _this2 = this;
 
         return _react2['default'].createElement(
           'div',
-          null,
+          { className: 'toggleView', style: this.props.style },
           _react2['default'].createElement(_ClusterThumbView2['default'], {
             element: this.getThumbElement(),
             style: this.props.thumbViewStyle,
@@ -115,19 +115,6 @@ var ClusterToggleView = function (_React$Component) {
                 onClick: _this2.onToggleView });
             }
           }()
-        );
-      }
-
-      return getView;
-    }()
-  }, {
-    key: 'render',
-    value: function () {
-      function render() {
-        return _react2['default'].createElement(
-          'div',
-          null,
-          this.getView()
         );
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onesie-toggle-environment-block",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "React Component that allows toggling between a thumbnail view and a detail view",
   "main": "lib/index.js",
   "scripts": {

--- a/src/ClusterThumbView/ClusterThumbView.jsx
+++ b/src/ClusterThumbView/ClusterThumbView.jsx
@@ -8,11 +8,9 @@ class ClusterThumbView extends React.Component{
 
   style(){
     var style = {
-      width: "10em",
+      minWidth: "10em",
       minHeight: "10em",
-      float: "left",
-      margin: ".5em",
-      backgroundColor: "#FFFFFF"
+      backgroundColor: "#FFFFFF",
     };
     return Object.assign({}, style , this.props.style);
   }

--- a/src/ClusterToggleView/ClusterToggleView.jsx
+++ b/src/ClusterToggleView/ClusterToggleView.jsx
@@ -21,16 +21,15 @@ class ClusterToggleView extends React.Component{
     this.getDetailElement = this.getDetailElement.bind(this);
 
     if(React.Children.count(this.props.children) > 2){
-      throw new Error("Too many Children Elements");
+      throw new Error("Too many Child Elements");
     }
   }
-
 
   getThumbElement(){
     if(this.props.thumbElement){
       return this.props.thumbElement;
-    } else if(React.Children.count(this.props.children) === 2){
-      return this.props.children[0];
+    } else if(React.Children.count(this.props.children) >= 1){
+      return Array.isArray(this.props.children)? this.props.children[0] : this.props.children;
     } else {
       throw new Error("No Thumb Element to Render");
     }
@@ -51,10 +50,10 @@ class ClusterToggleView extends React.Component{
     this.setState({mode: newMode});
   }
 
-  getView() {
+  render() {
     return (
-        <div>
-          <ClusterThumbView 
+      <div className="toggleView" style={this.props.style}>
+        <ClusterThumbView 
             element={this.getThumbElement()}
             style={this.props.thumbViewStyle}
             onClick={this.onToggleView}/>
@@ -66,14 +65,6 @@ class ClusterToggleView extends React.Component{
                         onClick={this.onToggleView}/>
             }
           })()}
-        </div>
-        );
-  }
-
-  render() {
-    return (
-      <div>
-        {this.getView()}
       </div>
             );
   }


### PR DESCRIPTION
- You can now render a thumb element without needing to add a detail element
- CSS is simplified to avoid collisions with user-defined CSS. 
